### PR TITLE
location -> window.location

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -26,7 +26,7 @@ export default function livereload(options = { watch: '' }) {
   return {
     name: 'livereload',
     banner() {
-      return `(function(l, i, v, e) { v = l.createElement(i); v.async = 1; v.src = '//' + (location.host || 'localhost').split(':')[0] + ':${port}/livereload.js?snipver=1'; e = l.getElementsByTagName(i)[0]; e.parentNode.insertBefore(v, e)})(document, 'script');`
+      return `(function(l, i, v, e) { v = l.createElement(i); v.async = 1; v.src = '//' + (window.location.host || 'localhost').split(':')[0] + ':${port}/livereload.js?snipver=1'; e = l.getElementsByTagName(i)[0]; e.parentNode.insertBefore(v, e)})(document, 'script');`
     },
     generateBundle() {
       if (!enabled) {


### PR DESCRIPTION
Prevents "Uncaught (in promise) ReferenceError: Cannot access 'location' before initialization".