### PR TITLE
Client script should only be added once

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "rollup -c",
     "dev": "rollup -cw",
     "lint": "standard rollup.config.js src/**",
-    "prepublish": "npm run build"
+    "prepare": "npm run build"
   },
   "keywords": [
     "rollup",

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,7 @@ export default function livereload (options = { watch: '' }) {
 
   let enabled = options.verbose === false
   const port = options.port || 35729
+  const clientUrl = options.clientUrl || ''
   const server = createServer(options)
 
   // Start watching
@@ -26,16 +27,17 @@ export default function livereload (options = { watch: '' }) {
   return {
     name: 'livereload',
     banner () {
-      function inject (port) {
+      function inject (port, clientUrl) {
         if (!document.getElementById('livereload')) {
+          const url = clientUrl || '//' + (window.location.host || 'localhost').split(':')[0] + ':' + port + '/livereload.js?snipver=1';
           const el = document.createElement('script')
           el.id = 'livereload'
           el.async = 1
-          el.src = '//' + (window.location.host || 'localhost').split(':')[0] + ':' + port + '/livereload.js?snipver=1'
+          el.src = url
           document.head.appendChild(el)
         }
       }
-      return (`(${inject.toString()})(${port});`)
+      return (`(${inject.toString()})(${port}, '${clientUrl}');`)
     },
     generateBundle () {
       if (!enabled) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import { createServer } from 'livereload'
 import { resolve } from 'path'
 
-export default function livereload(options = { watch: '' }) {
+export default function livereload (options = { watch: '' }) {
   if (typeof options === 'string') {
     options = {
       watch: options
@@ -10,7 +10,7 @@ export default function livereload(options = { watch: '' }) {
     options.watch = options.watch || ''
   }
 
-  var enabled = options.verbose === false
+  let enabled = options.verbose === false
   const port = options.port || 35729
   const server = createServer(options)
 
@@ -25,10 +25,19 @@ export default function livereload(options = { watch: '' }) {
 
   return {
     name: 'livereload',
-    banner() {
-      return `(function(l, i, v, e) { v = l.createElement(i); v.async = 1; v.src = '//' + (window.location.host || 'localhost').split(':')[0] + ':${port}/livereload.js?snipver=1'; e = l.getElementsByTagName(i)[0]; e.parentNode.insertBefore(v, e)})(document, 'script');`
+    banner () {
+      function inject (port) {
+        if (!document.getElementById('livereload')) {
+          const el = document.createElement('script')
+          el.id = 'livereload'
+          el.async = 1
+          el.src = '//' + (window.location.host || 'localhost').split(':')[0] + ':' + port + '/livereload.js?snipver=1'
+          document.head.appendChild(el)
+        }
+      }
+      return (`(${inject.toString()})(${port});`)
     },
-    generateBundle() {
+    generateBundle () {
       if (!enabled) {
         enabled = true
         console.log(green('LiveReload enabled'))
@@ -37,11 +46,11 @@ export default function livereload(options = { watch: '' }) {
   }
 }
 
-function green(text) {
+function green (text) {
   return '\u001b[1m\u001b[32m' + text + '\u001b[39m\u001b[22m'
 }
 
-function closeServerOnTermination(server) {
+function closeServerOnTermination (server) {
   const terminationSignals = ['SIGINT', 'SIGTERM']
   terminationSignals.forEach(signal => {
     process.on(signal, () => {


### PR DESCRIPTION
Thanks for writing this plugin, just what I needed!

My project uses multiple chunks so I end up getting multiple script tags (since each chunk has the banner). This fixes it by checking for the script's existence before adding it.

I also refactored a little bit, using an actual function with `toString()`, which makes the banner method a bit easier to read/edit.