### PR TITLE
fix livereload version to 0.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "rollup": "^1.0.0"
   },
   "dependencies": {
-    "livereload": "^0.8.0"
+    "livereload": "0.8.0"
   },
   "devDependencies": {
     "rollup": "1",


### PR DESCRIPTION
livereload 0.8.1 is broken, it does not send the reload commands to the browser.

To replicate, the easiest way is to do the svelte quickstart:

```
npx degit sveltejs/template my-svelte-project
cd my-svelte-project

npm install
npm run dev
```

You will notice that it doesn't live reload on config changes. Rolling back to 0.8.0 via `npm install livereload@0.8.0` resolves the issue and the reloading works again.