### PR TITLE
document => window.document

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -27,7 +27,7 @@ export default function livereload (options = { watch: '' }) {
   return {
     name: 'livereload',
     banner() {
-      return `(function(l, r) { if (l.getElementById('livereloadscript')) return; r = l.createElement('script'); r.async = 1; r.src = ${snippetSrc}; r.id = 'livereloadscript'; l.head.appendChild(r) })(document);`
+      return `(function(l, r) { if (l.getElementById('livereloadscript')) return; r = l.createElement('script'); r.async = 1; r.src = ${snippetSrc}; r.id = 'livereloadscript'; l.head.appendChild(r) })(window.document);`
     },
     generateBundle () {
       if (!enabled) {


### PR DESCRIPTION
Context:
- I'm using Rollup and dynamic imports to code-split my bundle
- The bundle output format is es modules
- babel is used to transpile and add polyfills to target browsers supporting es modules


In this scenario, the `livereload` script injected at the top of each chunk throws an error, because somehow `document` is `undefined`. A few additional notes:
- the error seems to happen only in dynamically imported modules
- the error seems to happen only if babel adds polyfills to the bundle

This error is quite problematic, since it causes the whole script to stop executing. I haven't spent a lot of time investigating the issue, but a fix seems to be using `window.document` instead of `document`.

@thgh , do you have any idea why this error might be happening? do you see any issues with the fix i'm proposing?

Thank you!