### PR TITLE
close previous server on Rollup reload

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,6 @@ import { createServer } from 'livereload'
 import { resolve } from 'path'
 
 let server
-let removeTerminationListeners
 
 export default function livereload(options = { watch: '' }) {
   if (typeof options === 'string') {
@@ -13,21 +12,17 @@ export default function livereload(options = { watch: '' }) {
     options.watch = options.watch || ''
   }
 
-  // release previous server instance if rollup is reloading configuration in watch mode
+  // release previous server instance if rollup is reloading configuration
+  // in watch mode
   if (server) {
     server.close()
     server = null
-  }
-  // we need to release previous listeners, or livereload will try to close
-  // already closed servers on termination
-  if (removeTerminationListeners) {
-    removeTerminationListeners()
-    removeTerminationListeners = null
   }
 
   let enabled = options.verbose === false
   const port = options.port || 35729
   const snippetSrc = options.clientUrl ? JSON.stringify(options.clientUrl) : `'//' + (window.location.host || 'localhost').split(':')[0] + ':${port}/livereload.js?snipver=1'`
+
   server = createServer(options)
 
   // Start watching
@@ -36,8 +31,6 @@ export default function livereload(options = { watch: '' }) {
   } else {
     server.watch(resolve(process.cwd(), options.watch))
   }
-
-  removeTerminationListeners = closeServerOnTermination(server);
 
   return {
     name: 'livereload',
@@ -55,25 +48,4 @@ export default function livereload(options = { watch: '' }) {
 
 function green (text) {
   return '\u001b[1m\u001b[32m' + text + '\u001b[39m\u001b[22m'
-}
-
-function closeServerOnTermination (server) {
-  const terminationSignals = ['SIGINT', 'SIGTERM']
-
-  const listener = () => {
-    server.close()
-    process.exit()
-  }
-
-  const cleanup = () => {
-    terminationSignals.forEach(signal => {
-      process.removeListener(signal, listener)
-    })
-  }
-
-  terminationSignals.forEach(signal => {
-    process.on(signal, listener)
-  })
-
-  return cleanup
 }


### PR DESCRIPTION
Fixes #30 #31 #32 (also [svelte#3528](https://github.com/sveltejs/svelte/issues/3528))

Used your solution from `rollup-plugin-server` to avoid EADDRINUSE error.

~~I've also disabled watching SIGINT & al by default, because in my experience this does more harm than good. This can easily conflict with other plugins that do the same, and the first one calling `process.exit()` ends up preventing proper cleanup for others. It seems that letting Node default handler take care of Ctrl+C works fine and yields better results overall. There's something I might have missed though...~~ (Following discussion with @trbrc, I've left signal handling out of this PR)