### PR TITLE
chore: update livereload to 0.9.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "rollup": "^1.0.0"
   },
   "dependencies": {
-    "livereload": "0.8.0 || ^0.8.2"
+    "livereload": "^0.9.1"
   },
   "devDependencies": {
     "rollup": "1",


### PR DESCRIPTION
Thanks to [chokidar v3](https://paulmillr.com/posts/chokidar-3-save-32tb-of-traffic/), livereload reduced install size [significantly](https://packagephobia.now.sh/result?p=livereload) in 0.9.x, we may take advantage of that too.

No breaking change in 0.9.x according to [changelog](https://github.com/napcs/node-livereload/blob/master/README.md#changelog)