### PR TITLE
codesandbox fix for multiple ports

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@ export default function livereload (options = { watch: '' }) {
   const snippetSrc = options.clientUrl
     ? JSON.stringify(options.clientUrl)
     : process.env.CODESANDBOX_SSE
-    ? `'//' + (window.location.host.replace(/^([^.]+)-\d+/,"$1").replace(/^([^\.]+)/, "$1"+port)).split(':')[0] + '/livereload.js?snipver=1&port=443'`
+    ? `'//' + (window.location.host.replace(/^([^.]+)-\d+/,"$1").replace(/^([^\.]+)/, "$1${port}")).split(':')[0] + '/livereload.js?snipver=1&port=443'`
     : `'//' + (window.location.host || 'localhost').split(':')[0] + ':${port}/livereload.js?snipver=1'`
   const server = createServer(options)
 

--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@ export default function livereload (options = { watch: '' }) {
   const snippetSrc = options.clientUrl
     ? JSON.stringify(options.clientUrl)
     : process.env.CODESANDBOX_SSE
-    ? `'//' + (window.location.host.replace(/^([^.]+)-\d+/,"$1").replace(/^([^\.]+)/, "$1${port}")).split(':')[0] + '/livereload.js?snipver=1&port=443'`
+    ? `'//' + (window.location.host.replace(/^([^.]+)-\d+/,"$1").replace(/^([^\.]+)/, "$1-${port}")).split(':')[0] + '/livereload.js?snipver=1&port=443'`
     : `'//' + (window.location.host || 'localhost').split(':')[0] + ':${port}/livereload.js?snipver=1'`
   const server = createServer(options)
 

--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@ export default function livereload (options = { watch: '' }) {
   const snippetSrc = options.clientUrl
     ? JSON.stringify(options.clientUrl)
     : process.env.CODESANDBOX_SSE
-    ? `'//' + (window.location.host.replace(/^([^.]+)-\d+/,"$1").replace(/^([^\.]+)/, "$1-${port}")).split(':')[0] + '/livereload.js?snipver=1&port=443'`
+    ? `'//' + (window.location.host.replace(/^([^.]+)-\\d+/,"$1").replace(/^([^\.]+)/, "$1-${port}")).split(':')[0] + '/livereload.js?snipver=1&port=443'`
     : `'//' + (window.location.host || 'localhost').split(':')[0] + ':${port}/livereload.js?snipver=1'`
   const server = createServer(options)
 

--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@ export default function livereload (options = { watch: '' }) {
   const snippetSrc = options.clientUrl
     ? JSON.stringify(options.clientUrl)
     : process.env.CODESANDBOX_SSE
-    ? `'//' + (window.location.host.replace(/^([^\.]+)/, "$1-35729")).split(':')[0] + '/livereload.js?snipver=1&port=443'`
+    ? `'//' + (window.location.host.replace(/^([^.]+)-\d+/,"$1").replace(/^([^\.]+)/, "$1"+port)).split(':')[0] + '/livereload.js?snipver=1&port=443'`
     : `'//' + (window.location.host || 'localhost').split(':')[0] + ':${port}/livereload.js?snipver=1'`
   const server = createServer(options)
 


### PR DESCRIPTION
The last PR only solved livereload for apps that were served on the main port, which unfortunately would often go to livereload itself.

733nr.sse.codesandbox.io **worked before**
733nr-5000.sse.codesandbox.io **didn't work before**

This PR also supports user defined ports.