### PR TITLE
fix: prevent server restarts in watch mode

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ import { find } from 'port-authority'
 
 const state = (global.PLUGIN_LIVERELOAD = global.PLUGIN_LIVERELOAD || {
   server: null,
+  port: null,
 })
 
 export default function livereload(options = { watch: '' }) {
@@ -15,16 +16,14 @@ export default function livereload(options = { watch: '' }) {
     options.watch = options.watch || ''
   }
 
-  // release previous server instance if rollup is reloading configuration
-  // in watch mode
-  if (state.server) {
-    state.server.close()
-  }
-
   let enabled = options.verbose === false
-  const portPromise = find(options.port || 35729)
+  const portPromise = state.port ? Promise.resolve(state.port) : find(options.port || 35729);
 
   portPromise.then(port => {
+    // state.server is already set, we must be in watch mode and already have
+    // the server running.
+    if( state.server) return;
+    state.port = port;
     state.server = createServer({ ...options, port })
 
     // Start watching


### PR DESCRIPTION
Hey, I noticed some slightly weird behaviour if you change your rollup config while in watch mode  Somewhat randomly, livereload would stop working and you'd have to refresh the page.  Not a huge deal, but I was curious and I think these changes should fix it.

What seems to be happening is that, if rollup is in watch mode and the rollup.config is changed, this triggers a restart of the livereload server.  This restart can reset the connection between the browser and the server requiring users to manually reload.

This PR changes that so the server is cached in memory and subsequent livereload() calls use that version.
