### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ npm install --save-dev rollup-plugin-livereload
 import livereload from 'rollup-plugin-livereload'
 
 export default {
-  entry: 'entry.js',
-  dest: 'bundle.js',
+  input: 'entry.js',
+  output: { file:'bundle.js' },
   plugins: [livereload()],
 }
 ```
@@ -43,8 +43,8 @@ import serve from 'rollup-plugin-serve'
 import livereload from 'rollup-plugin-livereload'
 
 export default {
-  entry: 'entry.js',
-  dest: 'bundle.js',
+  input: 'entry.js',
+  output: { file:'bundle.js' },
   plugins: [
     serve(), // index.html should be in root of project
     livereload(),


### PR DESCRIPTION
Hello!

I love "livereload" as part of a build process with "rollup" - thank you very much for this plugin!

However: does "rollup" really have those configuration parameters ("entry" and "dest") mentioned in the "README"? Shouldn't one use "input" and "output.file" instead?

I've modified the README accordingly. If you find that useful, you may just merge it into your "master" branch.

With greetings from Germany,

Andreas Rozek