### PR TITLE
Use user-supplied alternative hostname

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,13 @@ export default {
 
 By default, it watches the current directory. If you also have css output, pass the folder to which the build files are written.
 
+This plugin supports the following options:
+* `clientUrl`: provide an alternative URL to the `livereload.js` script/resource. This URL is always preferred over all other generated URLs.
+* `clientHostname`: alternative hostname used instead of `localhost` or the site's current host, where the bundle is fetched from. Use this option when you include your bundle from a different host.
+
+All remaining options are passed to [`livereload.createServer()`][livereload].
+
+Example:
 ```
 livereload('dist')
 
@@ -74,8 +81,6 @@ livereload({
   }
 })
 ```
-
-Options are always passed to [`livereload.createServer()`][livereload]
 
 ## Changelog
 

--- a/src/index.js
+++ b/src/index.js
@@ -45,8 +45,8 @@ export default function livereload(options = { watch: '' }) {
       const snippetSrc = options.clientUrl
         ? JSON.stringify(options.clientUrl)
         : process.env.CODESANDBOX_SSE
-        ? `'//' + (self.location.host.replace(/^([^.]+)-\\d+/,"$1").replace(/^([^.]+)/, "$1-${port}")).split(':')[0] + '/livereload.js?snipver=1&port=443'`
-        : `'//' + (self.location.host || 'localhost').split(':')[0] + ':${port}/livereload.js?snipver=1'`
+        ? `'//' + (self.location.hostname.replace(/^([^.]+)-\\d+/,"$1").replace(/^([^.]+)/, "$1-${port}")) + '/livereload.js?snipver=1&port=443'`
+        : `'//' + (self.location.hostname || 'localhost') + ':${port}/livereload.js?snipver=1'`
       return `(function(l, r) { if (!l || l.getElementById('livereloadscript')) return; r = l.createElement('script'); r.async = 1; r.src = ${snippetSrc}; r.id = 'livereloadscript'; l.getElementsByTagName('head')[0].appendChild(r) })(self.document);`
     },
     async generateBundle() {

--- a/src/index.js
+++ b/src/index.js
@@ -44,6 +44,8 @@ export default function livereload(options = { watch: '' }) {
       const port = await portPromise
       const snippetSrc = options.clientUrl
         ? JSON.stringify(options.clientUrl)
+        : options.clientHostname
+        ? `'//${options.clientHostname}:${port}/livereload.js?snipver=1`
         : process.env.CODESANDBOX_SSE
         ? `'//' + (self.location.hostname.replace(/^([^.]+)-\\d+/,"$1").replace(/^([^.]+)/, "$1-${port}")) + '/livereload.js?snipver=1&port=443'`
         : `'//' + (self.location.hostname || 'localhost') + ':${port}/livereload.js?snipver=1'`


### PR DESCRIPTION
Please do not merge before #71, because changes are based on the same branch.

This PR adds an option `clientHostname` to the plugin, which allows users to define an alternative hostname to be used instead of the default lookup (`window.location.hostname`) or fallback (i.e. `localhost`).

This is useful if the bundle generated by rollup is included from a different host, than the local webserver is running. Example: The `index.html` is accessible/served by `https://host-a.local`, which includes the bundle through `https://host-b.local/bundle.js`. The injected loader script would lookup the current host and try to fetch it from `https://host-a.local/livereload.js`. However, the script is not available through that host, but the other one.

I could use `options.clientUrl` but then I would have to hard-code the whole URL, including the port. That would break as soon as the local webserver binds to a different port (e.g. because of rebinding).