### PR TITLE
Drop support for Node.js versions older than 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "index.d.ts"
   ],
   "engines": {
-    "node": ">=8.3"
+    "node": ">=16"
   },
   "dependencies": {
     "livereload": "^0.9.1"


### PR DESCRIPTION
Drops support for versions of Node.js older than 16. The reason for doing this is that I will be making some new changes that are not supported by older versions of Node.js. Specifically, to enable ESM support by using `"type": "module"` for the package.

Although we could still support older versions such as 14, these are no longer supported by the Node.js team. So it makes sense to cut this off at the latest supported LTS version.

This is a breaking change, so this will eventually require a major version bump when released.