### PR TITLE
Mark `port-authority` as an external dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,11 +38,11 @@
     "node": ">=8.3"
   },
   "dependencies": {
-    "livereload": "^0.9.1"
+    "livereload": "^0.9.1",
+    "port-authority": "^1.1.1"
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^9.0.0",
-    "port-authority": "^1.1.1",
     "rollup": "2",
     "rollup-plugin-serve": "1"
   }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -14,6 +14,6 @@ export default {
       format: 'es',
     },
   ],
-  external: ['livereload'].concat(builtinModules),
+  external: ['livereload', 'port-authority'].concat(builtinModules),
   plugins: [resolve()],
 }


### PR DESCRIPTION
Marks [`port-authority`](https://github.com/Rich-Harris/port-authority) as an external dependency, so that it's no longer bundled into the distribution. This also means that it is now included as a dependency, rather than a development dependency.