### PR TITLE
test: cleanup tests and increase their specificity

### DIFF
--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -1,18 +1,29 @@
-import { describe, expect, vi } from 'vitest'
-import { appendFileSync } from 'node:fs'
+import { afterAll, beforeAll, describe, expect, vi } from 'vitest'
+import { appendFileSync, readFileSync, writeFileSync } from 'node:fs'
 import { DELAY, createContext } from './shared'
+
+const FILE_TO_MODIFY = 'test/config/rollup.config.js'
 
 describe('config update', test => {
   let ctx = createContext('config')
+  let originalFile: string
+  beforeAll(() => {
+    originalFile = readFileSync(FILE_TO_MODIFY, 'utf-8')
+  })
+
   test('should trigger a reload', async t => {
     expect(ctx.reload).toHaveBeenCalledTimes(0)
 
-    // Update the entry file and check if it reloads
-    appendFileSync('test/config/rollup.config.js', '\nconsole.log("append")')
+    // Update the config file and check if it reloads
+    appendFileSync(FILE_TO_MODIFY, '\nconsole.log("append")')
     await new Promise(resolve => setTimeout(resolve, 1000 + DELAY))
     expect(ctx.reload).toHaveBeenCalledTimes(1)
     expect(ctx.reload).toHaveBeenCalledWith(
       expect.stringContaining('rollup.config.js')
     )
+  })
+
+  afterAll(() => {
+    writeFileSync(FILE_TO_MODIFY, originalFile, 'utf-8')
   })
 })

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -10,6 +10,9 @@ describe('config update', test => {
     // Update the entry file and check if it reloads
     appendFileSync('test/config/rollup.config.js', '\nconsole.log("append")')
     await new Promise(resolve => setTimeout(resolve, 1000 + DELAY))
-    expect(ctx.reload).toHaveBeenCalledTimes(0)
+    expect(ctx.reload).toHaveBeenCalledTimes(1)
+    expect(ctx.reload).toHaveBeenCalledWith(
+      expect.stringContaining('rollup.config.js')
+    )
   })
 })

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -17,10 +17,10 @@ describe('config update', test => {
     // Update the config file and check if it reloads
     appendFileSync(FILE_TO_MODIFY, '\nconsole.log("append")')
     await new Promise(resolve => setTimeout(resolve, 1000 + DELAY))
-    expect(ctx.reload).toHaveBeenCalledTimes(1)
     expect(ctx.reload).toHaveBeenCalledWith(
       expect.stringContaining('rollup.config.js')
     )
+    expect(ctx.reload).toHaveBeenCalledTimes(1)
   })
 
   afterAll(() => {

--- a/test/entry.test.ts
+++ b/test/entry.test.ts
@@ -10,11 +10,27 @@ describe('entry update', test => {
     // Update the entry file and check if it reloads
     appendFileSync('test/entry/entry.js', '\nconsole.log("append")')
     await new Promise(resolve => setTimeout(resolve, DELAY))
-    expect(ctx.reload).toHaveBeenCalledTimes(1)
-
+    // since livereload is watching the entire folder, it will send two reload
+    // commands, one for the entry file and one for the bundle.
+    expect(ctx.reload).toHaveBeenNthCalledWith(
+      1,
+      expect.stringContaining('entry.js')
+    )
+    expect(ctx.reload).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining('dest.js')
+    )
     // Update the entry file and check if it reloads
     appendFileSync('test/entry/entry.js', '\nconsole.log("append")')
     await new Promise(resolve => setTimeout(resolve, DELAY))
-    expect(ctx.reload).toHaveBeenCalledTimes(2)
+    expect(ctx.reload).toHaveBeenNthCalledWith(
+      3,
+      expect.stringContaining('entry.js')
+    )
+    expect(ctx.reload).toHaveBeenNthCalledWith(
+      4,
+      expect.stringContaining('dest.js')
+    )
+    expect(ctx.reload).toHaveBeenCalledTimes(4)
   })
 })

--- a/test/entry.test.ts
+++ b/test/entry.test.ts
@@ -1,14 +1,20 @@
-import { describe, expect, vi } from 'vitest'
-import { appendFileSync } from 'node:fs'
+import { afterAll, beforeAll, describe, expect, vi } from 'vitest'
+import { appendFileSync, readFileSync, writeFileSync } from 'node:fs'
 import { DELAY, createContext } from './shared'
+
+const FILE_TO_MODIFY = 'test/entry/entry.js'
 
 describe('entry update', test => {
   let ctx = createContext('entry')
+  let originalFile: string
+  beforeAll(() => {
+    originalFile = readFileSync(FILE_TO_MODIFY, 'utf-8')
+  })
   test('should trigger a reload', async t => {
     expect(ctx.reload).toHaveBeenCalledTimes(0)
 
     // Update the entry file and check if it reloads
-    appendFileSync('test/entry/entry.js', '\nconsole.log("append")')
+    appendFileSync(FILE_TO_MODIFY, '\nconsole.log("append")')
     await new Promise(resolve => setTimeout(resolve, DELAY))
     // since livereload is watching the entire folder, it will send two reload
     // commands, one for the entry file and one for the bundle.
@@ -21,7 +27,7 @@ describe('entry update', test => {
       expect.stringContaining('dest.js')
     )
     // Update the entry file and check if it reloads
-    appendFileSync('test/entry/entry.js', '\nconsole.log("append")')
+    appendFileSync(FILE_TO_MODIFY, '\nconsole.log("append")')
     await new Promise(resolve => setTimeout(resolve, DELAY))
     expect(ctx.reload).toHaveBeenNthCalledWith(
       3,
@@ -32,5 +38,9 @@ describe('entry update', test => {
       expect.stringContaining('dest.js')
     )
     expect(ctx.reload).toHaveBeenCalledTimes(4)
+  })
+
+  afterAll(() => {
+    writeFileSync(FILE_TO_MODIFY, originalFile, 'utf-8')
   })
 })

--- a/test/shared.ts
+++ b/test/shared.ts
@@ -48,17 +48,11 @@ export function createContext(folder = 'entry') {
           client.send(JSON.stringify({ command: 'info', url: ctx.url + '/' }))
           resolve(client)
         }
-        if (
-          data.command === 'reload' &&
-          data.path.endsWith(folder + '/dest.js')
-        ) {
+        if (data.command === 'reload') {
           ctx.reload(data.path)
         }
       })
     })
-
-    // Ignore reloads in the first second
-    await new Promise(resolve => setTimeout(resolve, 1000))
 
     ctx.reload = vi.fn((path: string) => {})
   })


### PR DESCRIPTION
Hey, I noticed that the tests are a little flaky when I revisited https://github.com/thgh/rollup-plugin-livereload/pull/64

This is my attempt to tighten the tests a little so that, hopefully, they're more reliable. And, if they aren't, the output should be more descriptive. Also, the config test now checks to see if a reload is triggered by changes to the config file.

Finally, I prevented the console logs from building up and requiring you to clean up the files after running the tests.

I hope this isn't too much for one PR. If it is I'd be happy to split it up.